### PR TITLE
change text 'provid'->'provider'

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ source env.sh # Copy and fill env.sh.sample
 ```
 bundle
 librarian-chef install
-vagrant up --provide=aws
+vagrant up --provider=aws
 ```
 
 and reboot instance.


### PR DESCRIPTION
I think README.md has some tyop.

Before : vagrant up --provide=aws
After    : vagrant up --provider=aws
